### PR TITLE
Correctly parse shell command

### DIFF
--- a/lowatt_collect.py
+++ b/lowatt_collect.py
@@ -38,6 +38,7 @@ from concurrent import futures
 import logging
 import os
 from os.path import abspath, dirname, isdir, join, relpath
+import shlex
 from shutil import move
 import subprocess
 import sys
@@ -376,7 +377,7 @@ def _call(env, base_cmd, files=()):
     errors = []
 
     try:
-        cmd = [arg.format(**env) for arg in base_cmd.split()]
+        cmd = [arg.format(**env) for arg in shlex.split(base_cmd)]
 
     except KeyError as exc:
         LOGGER.error(

--- a/test/test_lowatt_collect.py
+++ b/test/test_lowatt_collect.py
@@ -166,6 +166,27 @@ class CollectTC(unittest.TestCase):
                 )
                 self.assertEOF(stream)
 
+    def test_shell_parser(self):
+        with TemporaryDirectory() as tmpdir:
+            collect(
+                {
+                    's1': {
+                        'collect': '{HERE}/echofile.py {DIR}/s1.file "foo" \'bar\'',  # noqa
+                        'postcollect': [],
+                    },
+                },
+                env={'HERE': dirname(__file__)},
+                postcollect_args=False,
+                root_directory=tmpdir,
+            )
+
+            with open(join(tmpdir, 's1', 's1.file')) as stream:
+                self.assertEqual(
+                    stream.readline().strip(),
+                    'foo bar',
+                )
+                self.assertEOF(stream)
+
     def test_collect_no_postcollect_args(self):
         with TemporaryDirectory() as tmpdir:
             collect(


### PR DESCRIPTION
The command may contains quotes and others. Use shlex.split() to handle
this.