### PR TITLE
Make collect specific source working with relative or absolute directories

### DIFF
--- a/lowatt_collect.py
+++ b/lowatt_collect.py
@@ -513,8 +513,10 @@ def _run():
         if args.sources:
             sources = {}
             for source in args.sources:
+                if source.startswith(root):
+                    source = os.path.relpath(source, root)
                 basedict = config['sources']
-                for key in source.split('.'):
+                for key in source.split(os.path.sep):
                     try:
                         basedict = basedict[key]
                     except KeyError:

--- a/test/test_lowatt_collect.py
+++ b/test/test_lowatt_collect.py
@@ -508,6 +508,15 @@ class CLITC(unittest.TestCase):
             output.splitlines()[0] + '...',
         )
 
+    def test_collect_specific_source_absolute(self):
+        sys.argv = ['lowatt-collect', 'collect',
+                    join(THIS_DIR, 'sources.yml'), join(DATA_DIR, 's2')]
+
+        stream = StringIO()
+        with redirect_stdout(stream), self.assertRaises(SystemExit) as cm:
+            run()
+        self.assertEqual(cm.exception.code, 0)
+
     def test_collect_specific_source_extra_args(self):
         sys.argv = ['lowatt-collect', 'collect',
                     join(THIS_DIR, 'sources.yml'), 's2', '--hop', 'extra']


### PR DESCRIPTION
Until now we used the '.' as separator, use normal path separator
instead.

Also accept absolute directories, e.g. passing /data/foo will collect
for "foo" if root is /data.